### PR TITLE
mocks server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The `index.html` in the `app` folder is especially important - it contains marke
 - Live-reload capability: web app is auto-refreshed if HTML, TypeScript or Sass files change,
 - watch tasks: if your source files change, they will be checked for errors, compiled and then injected into your application,
  Gript uses [Chokidar](https://github.com/paulmillr/chokidar) which notices the changes instantly, keeping the CPU usage down at the same time,
+- contains the mock server based on `YAML/JSON/JS` configuration files. Refer to the [Mock Server](#mocks) section for usage guidelines.
 - contains the locked set of specific `npm` dependencies, to minimize "the dependency hell".
 
 ## Structure requirements for applications supported
@@ -46,6 +47,7 @@ The use of the this Gulp build tool is based on applications code being structur
     |     |---- .eslint.rc.yml
     |---- /bower_components
     |---- /target
+    |---- /mocks
     |     |---- dist
     |     |---- tmp
     |---- gulpfile.js
@@ -66,6 +68,7 @@ which means:
 - `node_modules` : tools downloaded by [npm](https://www.npmjs.org/)
 - `target/tmp` : contains generated files (compiled TypeScript, compiled Sass styles, Angular templates etc.)
 - `target/dist` : contains app distribution package
+- `mocks` : contains your mock services definitions.
 - `gulpfile.js` : the build files importing the [Gulp](http://gulpjs.com) tasks defined in the `node_modules/gript`
 - `bower.json` : contains [Bower](http://bower.io) dependencies
 - `.eslint.rc.yml` : contains rules for es-linter ([ESLint](http://eslint.org)). Cascading rules configuration is possible.
@@ -120,6 +123,16 @@ This `sample_configs/gulpfile.js` can be used as a starter for your project. Thi
                    port: 35729
                }
            },
+           mocks: {
+			   location: 'localhost',
+			   stubs: 8050,
+			   tls: 8443,
+			   admin: 8051,
+			   relativeFilesPath: true,
+			   files: [
+				   'mocks/*.{json,yaml,js}'
+			   ]
+		   },
            typeScript: {
                compilerOptions: {
                    noImplicitAny: true,
@@ -211,6 +224,7 @@ The `gulpfile.js` from Gript contains also these specific tasks:
 - **watch** : watches the source code for changes and runs the relevant task(s) whenever something changes
 - **server** : starts a development server
 - **server:dist** : starts a server using the deployment directory (`target/dist`)
+- **mocks** : starts a server with mock services. Refer to the [Mock server](#mocks) section for guidelines.
 
 You can list all of the available tasks by running the command:
 
@@ -273,6 +287,19 @@ The result will be injected into `target/dist/index.html` according to these inj
 - `<!-- build:js scripts/main.js --><!-- endbuild -->`: your own scripts
 
 Refer to `app/index.html` or `sample_configs/index.html` for an example how to define these markings.
+
+<a name="mocks"></a>
+## Mock server
+The mock server implementation in Gript is using [stubby4node](https://github.com/mrak/stubby4node).
+It's a highly configurable server for mocking/stubbing external systems during development.
+Gript takes endpoint descriptors in the form of a YAML or JSON files that tell it how to respond to incoming requests.
+For each incoming request, configured endpoints are checked in-order until a match is found.
+The endpoints can contain regular expressions, any of HTTP methods, queries, headers, dynamic token interpolation, defined fake response latency and so on.
+The response can be parametrized or served from a file - the possiblities are endless.
+Refer to the Stubby [endpoint configuration](https://github.com/mrak/stubby4node#endpoint-configuration) section for assistance how to define your own endpoints.
+By default, the `mocks` Gulp task will start together with the `server` and `server:dist` tasks.
+Gript contains some simple endpoints definitions in the `mocks` and `sample_config/mocks` directory to get your started.
+You can customize the mocks directory name and server ports in the `mocks` section of your `gulpfile.js`.
 
 ## External dependencies
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,16 @@ gulp.config = {
             port: 35729
         }
     },
+    mocks: {
+        location: 'localhost',
+        stubs: 8050,
+        tls: 8443,
+        admin: 8051,
+        relativeFilesPath: true,
+        files: [
+            'mocks/*.{json,yaml,js}'
+        ]
+    },
     typeScript: {
         compilerOptions: {
             noImplicitAny: true,

--- a/mocks/data/example.json
+++ b/mocks/data/example.json
@@ -1,0 +1,227 @@
+[
+  {
+    "_id": "56c03bb78aea0e52d0c5f3fc",
+    "index": 0,
+    "guid": "d3b47dfc-f5e7-47d0-9094-41b3d5f852ad",
+    "isActive": false,
+    "balance": "$2,098.21",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "brown",
+    "name": "Gill Frank",
+    "gender": "male",
+    "company": "OPTICALL",
+    "email": "gillfrank@opticall.com",
+    "phone": "+1 (926) 407-3030",
+    "address": "307 Woodside Avenue, Fredericktown, Idaho, 9401",
+    "about": "Do consequat velit ex nostrud proident cupidatat est ad enim. Excepteur officia id laboris pariatur consectetur laboris ullamco eu proident nostrud labore velit. Ipsum exercitation do ut mollit quis nisi sit exercitation magna.\r\n",
+    "registered": "2014-02-28T01:04:50 -01:00",
+    "latitude": -24.612261,
+    "longitude": -28.0196,
+    "tags": [
+      "anim",
+      "eu",
+      "tempor",
+      "nisi",
+      "dolore",
+      "laborum",
+      "aute"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Johnston Monroe"
+      },
+      {
+        "id": 1,
+        "name": "Stanley Baxter"
+      },
+      {
+        "id": 2,
+        "name": "Maxwell Macdonald"
+      }
+    ],
+    "greeting": "Hello, Gill Frank! You have 2 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "56c03bb756acb961a31932e2",
+    "index": 1,
+    "guid": "e8e6907c-64ec-41ab-b676-f130126f6095",
+    "isActive": true,
+    "balance": "$1,624.45",
+    "picture": "http://placehold.it/32x32",
+    "age": 26,
+    "eyeColor": "brown",
+    "name": "Mclean Randolph",
+    "gender": "male",
+    "company": "BLUPLANET",
+    "email": "mcleanrandolph@bluplanet.com",
+    "phone": "+1 (951) 453-3040",
+    "address": "611 King Street, Malott, Oklahoma, 9388",
+    "about": "Ipsum irure incididunt voluptate sit aliqua adipisicing dolore officia do commodo laborum. Ex minim eiusmod officia dolor nulla velit sit. Qui deserunt incididunt cupidatat Lorem amet irure tempor fugiat. Reprehenderit ut ex elit velit ullamco.\r\n",
+    "registered": "2015-05-01T03:17:20 -02:00",
+    "latitude": -63.920312,
+    "longitude": 108.935862,
+    "tags": [
+      "excepteur",
+      "nostrud",
+      "anim",
+      "anim",
+      "amet",
+      "laborum",
+      "cillum"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herring Haynes"
+      },
+      {
+        "id": 1,
+        "name": "Bright Schroeder"
+      },
+      {
+        "id": 2,
+        "name": "Millie Alexander"
+      }
+    ],
+    "greeting": "Hello, Mclean Randolph! You have 5 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "56c03bb766f77d04aa007778",
+    "index": 2,
+    "guid": "2a5cf553-013d-47ed-aae2-4a388b5973bc",
+    "isActive": true,
+    "balance": "$1,258.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 37,
+    "eyeColor": "green",
+    "name": "Crystal Kelly",
+    "gender": "female",
+    "company": "PHOTOBIN",
+    "email": "crystalkelly@photobin.com",
+    "phone": "+1 (894) 592-3778",
+    "address": "990 Ditmars Street, Kingstowne, Alabama, 8563",
+    "about": "Reprehenderit esse sint ipsum magna laborum dolore in non esse irure dolore et veniam. Ipsum et ex consequat consequat occaecat incididunt nostrud veniam et pariatur nisi Lorem. Id non fugiat anim veniam est ullamco. Duis in minim deserunt deserunt ex do excepteur ex eiusmod esse cillum. Occaecat nulla laboris pariatur Lorem nisi. Consectetur cillum sint nisi aliquip labore Lorem ea dolore fugiat cillum reprehenderit elit ad ex.\r\n",
+    "registered": "2015-12-12T05:26:29 -01:00",
+    "latitude": 36.367742,
+    "longitude": -110.934632,
+    "tags": [
+      "dolore",
+      "veniam",
+      "excepteur",
+      "in",
+      "aliqua",
+      "non",
+      "cillum"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Valentine Wise"
+      },
+      {
+        "id": 1,
+        "name": "Roberta Carter"
+      },
+      {
+        "id": 2,
+        "name": "Blanchard Kline"
+      }
+    ],
+    "greeting": "Hello, Crystal Kelly! You have 9 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "56c03bb7e6ccdba8a503deba",
+    "index": 3,
+    "guid": "89407d22-fe9f-400b-a76b-4ab14e55b093",
+    "isActive": true,
+    "balance": "$3,786.35",
+    "picture": "http://placehold.it/32x32",
+    "age": 38,
+    "eyeColor": "brown",
+    "name": "Blanca Stark",
+    "gender": "female",
+    "company": "DADABASE",
+    "email": "blancastark@dadabase.com",
+    "phone": "+1 (838) 457-2542",
+    "address": "335 Putnam Avenue, Alderpoint, Rhode Island, 8603",
+    "about": "Elit consectetur labore sunt sit sint laboris sint reprehenderit in eiusmod ut minim. Cillum aute et nisi fugiat consectetur cupidatat amet reprehenderit ullamco deserunt id. Consequat amet nisi excepteur officia ex deserunt ipsum. Reprehenderit ex voluptate elit est velit adipisicing proident irure.\r\n",
+    "registered": "2015-07-18T12:08:30 -02:00",
+    "latitude": 34.960217,
+    "longitude": -75.595715,
+    "tags": [
+      "consequat",
+      "consequat",
+      "dolor",
+      "excepteur",
+      "sint",
+      "quis",
+      "aliquip"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Eliza Mcknight"
+      },
+      {
+        "id": 1,
+        "name": "Cobb Flores"
+      },
+      {
+        "id": 2,
+        "name": "Vinson Carlson"
+      }
+    ],
+    "greeting": "Hello, Blanca Stark! You have 4 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "56c03bb771c40adbe6666f5e",
+    "index": 4,
+    "guid": "23c1c9b8-7855-4a78-ab8a-532c9d5655f9",
+    "isActive": false,
+    "balance": "$3,952.97",
+    "picture": "http://placehold.it/32x32",
+    "age": 30,
+    "eyeColor": "brown",
+    "name": "Bean Dickerson",
+    "gender": "male",
+    "company": "GORGANIC",
+    "email": "beandickerson@gorganic.com",
+    "phone": "+1 (889) 555-3422",
+    "address": "490 Fulton Street, Eagleville, District Of Columbia, 5122",
+    "about": "Non dolor officia incididunt voluptate aute consectetur reprehenderit occaecat dolor cupidatat. Duis nostrud ex et consectetur duis eiusmod in nisi. Ipsum quis occaecat dolor laborum aliquip magna ex ea mollit irure aliquip ipsum irure.\r\n",
+    "registered": "2014-01-27T08:03:18 -01:00",
+    "latitude": -9.90978,
+    "longitude": -140.72756,
+    "tags": [
+      "laboris",
+      "consequat",
+      "commodo",
+      "voluptate",
+      "qui",
+      "cillum",
+      "culpa"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Woods Everett"
+      },
+      {
+        "id": 1,
+        "name": "Amber Chambers"
+      },
+      {
+        "id": 2,
+        "name": "Dianne Walsh"
+      }
+    ],
+    "greeting": "Hello, Bean Dickerson! You have 3 unread messages.",
+    "favoriteFruit": "apple"
+  }
+]

--- a/mocks/dynamicTokens.json
+++ b/mocks/dynamicTokens.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "url": "^/account/(\\d{5})/category/([a-zA-Z]+)",
+    "query": {
+      "date": "([a-zA-Z]+)"
+    },
+    "headers": {
+      "custom-header": "[0-9]+"
+    },
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "body": "Returned invoice number# <% url[1] %> in category '<% url[2] %>' on the date '<% query.date[1] %>', using header custom-header <% headers.custom-header[0] %>"
+  }
+}

--- a/mocks/fromFile.json
+++ b/mocks/fromFile.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "url": "^/fromFile",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "content-type": "application/json",
+    "file": "data/example.json"
+  }
+}

--- a/mocks/simple.json
+++ b/mocks/simple.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "url": "^/simple",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": [
+      {
+        "name": "John",
+        "email": "john@example.com"
+      },
+      {
+        "name": "Jane",
+        "email": "jane@example.com"
+      }
+    ]
+  }
+}

--- a/mocks/slowResponse.json
+++ b/mocks/slowResponse.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "url": "^/slowResponse",
+    "method": "GET"
+  },
+  "response": {
+    "latency": 80000,
+    "status": 200,
+    "headers": {
+      "content-type": "application/json",
+      "body": [
+        {
+          "name": "John",
+          "email": "john@example.com"
+        },
+        {
+          "name": "Jane",
+          "email": "jane@example.com"
+        }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gript",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Gulp Build Setup",
   "dependencies": {
     "bower": "1.7.7",
@@ -40,6 +40,7 @@
     "gulp-scss-lint": "0.3.9",
     "gulp-size": "2.0.0",
     "gulp-sourcemaps": "1.6.0",
+    "gulp-stubby-server": "0.1.6",
     "gulp-tslint": "4.3.1",
     "gulp-util": "3.0.7",
     "tslint": "3.3.0",

--- a/package/README.md
+++ b/package/README.md
@@ -5,9 +5,9 @@ This project is the basis for the creation of an [npm module](https://www.npmjs.
 an [AngularJS](https://angularjs.org) application using [Sass](http://sass-lang.com). Your application source and test files can be written in JavaScript or [TypeScript](http://www.typescriptlang.org/).
 If it's TypeScript, it will be validated and then compiled to JavaScript.
 
-The goal of this tool is to provide the handy workflow for developing [Angular](https://angularjs.org) based applications (no matter what language you use - JavaScript or TypeScript)
+The goal of this tool is to provide the handy workflow for developing Angular based applications (no matter what language you use - JavaScript or TypeScript)
 and ensure the profound checking of the code quality at the same time.
-The module orchestrates a collection of Gulp build functionality into a single npm dependency
+The module orchestrates a collection of [Gulp](http://gulpjs.com) build functionality into a single npm dependency
 and makes it easier for developers to have and maintain the build setup for own Angular projects.
 
 The project includes a sample application to make it possible to test the build setup.
@@ -28,6 +28,7 @@ The `index.html` in the `app` folder is especially important - it contains marke
 - Live-reload capability: web app is auto-refreshed if HTML, TypeScript or Sass files change,
 - watch tasks: if your source files change, they will be checked for errors, compiled and then injected into your application,
  Gript uses [Chokidar](https://github.com/paulmillr/chokidar) which notices the changes instantly, keeping the CPU usage down at the same time,
+- contains the mock server based on `YAML/JSON/JS` configuration files. Refer to the [Mock Server](#mocks) section for usage guidelines.
 - contains the locked set of specific `npm` dependencies, to minimize "the dependency hell".
 
 ## Structure requirements for applications supported
@@ -46,6 +47,7 @@ The use of the this Gulp build tool is based on applications code being structur
     |     |---- .eslint.rc.yml
     |---- /bower_components
     |---- /target
+    |---- /mocks
     |     |---- dist
     |     |---- tmp
     |---- gulpfile.js
@@ -54,7 +56,7 @@ The use of the this Gulp build tool is based on applications code being structur
     |---- .eslint.rc.yml
     |---- .scsslint.rc.yml
     |---- tslint.json
-	|---- .htmllint.rc`
+    |---- .htmllint.rc
 
 which means:
 
@@ -66,6 +68,7 @@ which means:
 - `node_modules` : tools downloaded by [npm](https://www.npmjs.org/)
 - `target/tmp` : contains generated files (compiled TypeScript, compiled Sass styles, Angular templates etc.)
 - `target/dist` : contains app distribution package
+- `mocks` : contains your mock services definitions.
 - `gulpfile.js` : the build files importing the [Gulp](http://gulpjs.com) tasks defined in the `node_modules/gript`
 - `bower.json` : contains [Bower](http://bower.io) dependencies
 - `.eslint.rc.yml` : contains rules for es-linter ([ESLint](http://eslint.org)). Cascading rules configuration is possible.
@@ -120,6 +123,16 @@ This `sample_configs/gulpfile.js` can be used as a starter for your project. Thi
                    port: 35729
                }
            },
+           mocks: {
+			   location: 'localhost',
+			   stubs: 8050,
+			   tls: 8443,
+			   admin: 8051,
+			   relativeFilesPath: true,
+			   files: [
+				   'mocks/*.{json,yaml,js}'
+			   ]
+		   },
            typeScript: {
                compilerOptions: {
                    noImplicitAny: true,
@@ -151,7 +164,7 @@ This `sample_configs/gulpfile.js` can be used as a starter for your project. Thi
                    preserveComments: false
                }
            }
-       };
+	   };
 
 Be sure to set values for the configuration in your copy of the `sample_configs/gulpfile.js`.
 
@@ -211,6 +224,7 @@ The `gulpfile.js` from Gript contains also these specific tasks:
 - **watch** : watches the source code for changes and runs the relevant task(s) whenever something changes
 - **server** : starts a development server
 - **server:dist** : starts a server using the deployment directory (`target/dist`)
+- **mocks** : starts a server with mock services. Refer to the [Mock server](#mocks) section for guidelines.
 
 You can list all of the available tasks by running the command:
 
@@ -233,8 +247,8 @@ For your convenience, Gript contains sample configuration files for all linters 
 If you develop your app in the TypeScript, files will be compiled and then injected. The example setup uses [DefinitelyTyped](http://definitelytyped.org/)
  to get the TypeScript types definitions. They are being downloaded by [Bower](http://bower.io/) into the `bower_components/DefinitelyTyped` directory, which is excluded from the TypeScript linting.
  The resulting JavaScript files will be placed in the `target/tmp/js` directory.
-You can customize your TypeScript compile options using the `typeScript` section in the `gulpfile.js`.
-Refer to the [Compiler-Options](https://github.com/Microsoft/TypeScript/wiki/Compiler-Options) section in the TypeScript documentation for available options.
+ You can customize your TypeScript compile options using the `typeScript` section in the `gulpfile.js`.
+ Refer to the [Compiler-Options](https://github.com/Microsoft/TypeScript/wiki/Compiler-Options) section in the TypeScript documentation for available options.
 
 <a name="minification"></a>
 ## Minification
@@ -273,6 +287,19 @@ The result will be injected into `target/dist/index.html` according to these inj
 - `<!-- build:js scripts/main.js --><!-- endbuild -->`: your own scripts
 
 Refer to `app/index.html` or `sample_configs/index.html` for an example how to define these markings.
+
+<a name="mocks"></a>
+## Mock server
+The mock server implementation in Gript is using [stubby4node](https://github.com/mrak/stubby4node).
+It's a highly configurable server for mocking/stubbing external systems during development.
+Gript takes endpoint descriptors in the form of a YAML or JSON files that tell it how to respond to incoming requests.
+For each incoming request, configured endpoints are checked in-order until a match is found.
+The endpoints can contain regular expressions, any of HTTP methods, queries, headers, dynamic token interpolation, defined fake response latency and so on.
+The response can be parametrized or served from a file - the possiblities are endless.
+Refer to the Stubby [endpoint configuration](https://github.com/mrak/stubby4node#endpoint-configuration) section for assistance how to define your own endpoints.
+By default, the `mocks` Gulp task will start together with the `server` and `server:dist` tasks.
+Gript contains some simple endpoints definitions in the `mocks` and `sample_config/mocks` directory to get your started.
+You can customize the mocks directory name and server ports in the `mocks` section of your `gulpfile.js`.
 
 ## External dependencies
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gript",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Gulp Build Setup",
   "dependencies": {
     "bower": "1.7.7",
@@ -39,6 +39,7 @@
     "gulp-scss-lint": "0.3.9",
     "gulp-size": "2.0.0",
     "gulp-sourcemaps": "1.6.0",
+    "gulp-stubby-server": "0.1.6",
     "gulp-tslint": "4.3.1",
     "gulp-util": "3.0.7",
     "tslint": "3.3.0",

--- a/package/sample_configs/gulpfile.js
+++ b/package/sample_configs/gulpfile.js
@@ -19,6 +19,16 @@ gulp.config = {
             port: 35729
         }
     },
+    mocks: {
+        location: 'localhost',
+        stubs: 8050,
+        tls: 8443,
+        admin: 8051,
+        relativeFilesPath: true,
+        files: [
+            'mocks/*.{json,yaml,js}'
+        ]
+    },
     typeScript: {
         compilerOptions: {
             noImplicitAny: true,

--- a/package/sample_configs/mocks/data/example.json
+++ b/package/sample_configs/mocks/data/example.json
@@ -1,0 +1,227 @@
+[
+  {
+    "_id": "56c03bb78aea0e52d0c5f3fc",
+    "index": 0,
+    "guid": "d3b47dfc-f5e7-47d0-9094-41b3d5f852ad",
+    "isActive": false,
+    "balance": "$2,098.21",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "brown",
+    "name": "Gill Frank",
+    "gender": "male",
+    "company": "OPTICALL",
+    "email": "gillfrank@opticall.com",
+    "phone": "+1 (926) 407-3030",
+    "address": "307 Woodside Avenue, Fredericktown, Idaho, 9401",
+    "about": "Do consequat velit ex nostrud proident cupidatat est ad enim. Excepteur officia id laboris pariatur consectetur laboris ullamco eu proident nostrud labore velit. Ipsum exercitation do ut mollit quis nisi sit exercitation magna.\r\n",
+    "registered": "2014-02-28T01:04:50 -01:00",
+    "latitude": -24.612261,
+    "longitude": -28.0196,
+    "tags": [
+      "anim",
+      "eu",
+      "tempor",
+      "nisi",
+      "dolore",
+      "laborum",
+      "aute"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Johnston Monroe"
+      },
+      {
+        "id": 1,
+        "name": "Stanley Baxter"
+      },
+      {
+        "id": 2,
+        "name": "Maxwell Macdonald"
+      }
+    ],
+    "greeting": "Hello, Gill Frank! You have 2 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "56c03bb756acb961a31932e2",
+    "index": 1,
+    "guid": "e8e6907c-64ec-41ab-b676-f130126f6095",
+    "isActive": true,
+    "balance": "$1,624.45",
+    "picture": "http://placehold.it/32x32",
+    "age": 26,
+    "eyeColor": "brown",
+    "name": "Mclean Randolph",
+    "gender": "male",
+    "company": "BLUPLANET",
+    "email": "mcleanrandolph@bluplanet.com",
+    "phone": "+1 (951) 453-3040",
+    "address": "611 King Street, Malott, Oklahoma, 9388",
+    "about": "Ipsum irure incididunt voluptate sit aliqua adipisicing dolore officia do commodo laborum. Ex minim eiusmod officia dolor nulla velit sit. Qui deserunt incididunt cupidatat Lorem amet irure tempor fugiat. Reprehenderit ut ex elit velit ullamco.\r\n",
+    "registered": "2015-05-01T03:17:20 -02:00",
+    "latitude": -63.920312,
+    "longitude": 108.935862,
+    "tags": [
+      "excepteur",
+      "nostrud",
+      "anim",
+      "anim",
+      "amet",
+      "laborum",
+      "cillum"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Herring Haynes"
+      },
+      {
+        "id": 1,
+        "name": "Bright Schroeder"
+      },
+      {
+        "id": 2,
+        "name": "Millie Alexander"
+      }
+    ],
+    "greeting": "Hello, Mclean Randolph! You have 5 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "56c03bb766f77d04aa007778",
+    "index": 2,
+    "guid": "2a5cf553-013d-47ed-aae2-4a388b5973bc",
+    "isActive": true,
+    "balance": "$1,258.23",
+    "picture": "http://placehold.it/32x32",
+    "age": 37,
+    "eyeColor": "green",
+    "name": "Crystal Kelly",
+    "gender": "female",
+    "company": "PHOTOBIN",
+    "email": "crystalkelly@photobin.com",
+    "phone": "+1 (894) 592-3778",
+    "address": "990 Ditmars Street, Kingstowne, Alabama, 8563",
+    "about": "Reprehenderit esse sint ipsum magna laborum dolore in non esse irure dolore et veniam. Ipsum et ex consequat consequat occaecat incididunt nostrud veniam et pariatur nisi Lorem. Id non fugiat anim veniam est ullamco. Duis in minim deserunt deserunt ex do excepteur ex eiusmod esse cillum. Occaecat nulla laboris pariatur Lorem nisi. Consectetur cillum sint nisi aliquip labore Lorem ea dolore fugiat cillum reprehenderit elit ad ex.\r\n",
+    "registered": "2015-12-12T05:26:29 -01:00",
+    "latitude": 36.367742,
+    "longitude": -110.934632,
+    "tags": [
+      "dolore",
+      "veniam",
+      "excepteur",
+      "in",
+      "aliqua",
+      "non",
+      "cillum"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Valentine Wise"
+      },
+      {
+        "id": 1,
+        "name": "Roberta Carter"
+      },
+      {
+        "id": 2,
+        "name": "Blanchard Kline"
+      }
+    ],
+    "greeting": "Hello, Crystal Kelly! You have 9 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "56c03bb7e6ccdba8a503deba",
+    "index": 3,
+    "guid": "89407d22-fe9f-400b-a76b-4ab14e55b093",
+    "isActive": true,
+    "balance": "$3,786.35",
+    "picture": "http://placehold.it/32x32",
+    "age": 38,
+    "eyeColor": "brown",
+    "name": "Blanca Stark",
+    "gender": "female",
+    "company": "DADABASE",
+    "email": "blancastark@dadabase.com",
+    "phone": "+1 (838) 457-2542",
+    "address": "335 Putnam Avenue, Alderpoint, Rhode Island, 8603",
+    "about": "Elit consectetur labore sunt sit sint laboris sint reprehenderit in eiusmod ut minim. Cillum aute et nisi fugiat consectetur cupidatat amet reprehenderit ullamco deserunt id. Consequat amet nisi excepteur officia ex deserunt ipsum. Reprehenderit ex voluptate elit est velit adipisicing proident irure.\r\n",
+    "registered": "2015-07-18T12:08:30 -02:00",
+    "latitude": 34.960217,
+    "longitude": -75.595715,
+    "tags": [
+      "consequat",
+      "consequat",
+      "dolor",
+      "excepteur",
+      "sint",
+      "quis",
+      "aliquip"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Eliza Mcknight"
+      },
+      {
+        "id": 1,
+        "name": "Cobb Flores"
+      },
+      {
+        "id": 2,
+        "name": "Vinson Carlson"
+      }
+    ],
+    "greeting": "Hello, Blanca Stark! You have 4 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "56c03bb771c40adbe6666f5e",
+    "index": 4,
+    "guid": "23c1c9b8-7855-4a78-ab8a-532c9d5655f9",
+    "isActive": false,
+    "balance": "$3,952.97",
+    "picture": "http://placehold.it/32x32",
+    "age": 30,
+    "eyeColor": "brown",
+    "name": "Bean Dickerson",
+    "gender": "male",
+    "company": "GORGANIC",
+    "email": "beandickerson@gorganic.com",
+    "phone": "+1 (889) 555-3422",
+    "address": "490 Fulton Street, Eagleville, District Of Columbia, 5122",
+    "about": "Non dolor officia incididunt voluptate aute consectetur reprehenderit occaecat dolor cupidatat. Duis nostrud ex et consectetur duis eiusmod in nisi. Ipsum quis occaecat dolor laborum aliquip magna ex ea mollit irure aliquip ipsum irure.\r\n",
+    "registered": "2014-01-27T08:03:18 -01:00",
+    "latitude": -9.90978,
+    "longitude": -140.72756,
+    "tags": [
+      "laboris",
+      "consequat",
+      "commodo",
+      "voluptate",
+      "qui",
+      "cillum",
+      "culpa"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Woods Everett"
+      },
+      {
+        "id": 1,
+        "name": "Amber Chambers"
+      },
+      {
+        "id": 2,
+        "name": "Dianne Walsh"
+      }
+    ],
+    "greeting": "Hello, Bean Dickerson! You have 3 unread messages.",
+    "favoriteFruit": "apple"
+  }
+]

--- a/package/sample_configs/mocks/dynamicTokens.json
+++ b/package/sample_configs/mocks/dynamicTokens.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "url": "^/account/(\\d{5})/category/([a-zA-Z]+)",
+    "query": {
+      "date": "([a-zA-Z]+)"
+    },
+    "headers": {
+      "custom-header": "[0-9]+"
+    },
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "body": "Returned invoice number# <% url[1] %> in category '<% url[2] %>' on the date '<% query.date[1] %>', using header custom-header <% headers.custom-header[0] %>"
+  }
+}

--- a/package/sample_configs/mocks/fromFile.json
+++ b/package/sample_configs/mocks/fromFile.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "url": "^/fromFile",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "content-type": "application/json",
+    "file": "data/example.json"
+  }
+}

--- a/package/sample_configs/mocks/simple.json
+++ b/package/sample_configs/mocks/simple.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "url": "^/simple",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": [
+      {
+        "name": "John",
+        "email": "john@example.com"
+      },
+      {
+        "name": "Jane",
+        "email": "jane@example.com"
+      }
+    ]
+  }
+}

--- a/package/sample_configs/mocks/slowResponse.json
+++ b/package/sample_configs/mocks/slowResponse.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "url": "^/slowResponse",
+    "method": "GET"
+  },
+  "response": {
+    "latency": 5000,
+    "status": 200,
+    "headers": {
+      "content-type": "application/json",
+      "body": [
+        {
+          "name": "John",
+          "email": "john@example.com"
+        },
+        {
+          "name": "Jane",
+          "email": "jane@example.com"
+        }
+      ]
+    }
+  }
+}

--- a/tasks/mock.gulp.js
+++ b/tasks/mock.gulp.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = function (gulp) {
+
+    var mocks = require('gulp-stubby-server'),
+        _ = require('lodash'),
+        defaults = {
+            location: 'localhost',
+            stubs: 8050,
+            tls: 8443,
+            admin: 8051,
+            relativeFilesPath: true,
+            files: [
+                'mocks/*.{json,yaml,js}'
+            ]
+        };
+
+    gulp.task('mocks', function (cb) {
+        var config = _.merge({}, defaults, gulp.config.mocks);
+
+        mocks(config, cb);
+    });
+};

--- a/tasks/server.gulp.js
+++ b/tasks/server.gulp.js
@@ -14,12 +14,12 @@ module.exports = function (gulp) {
             }
         };
 
-    gulp.task('server', function () {
+    gulp.task('server', ['mocks'], function () {
         var options = _.merge({}, defaults, gulp.config.server);
         connect.server(options);
     });
 
-    gulp.task('server:dist', function () {
+    gulp.task('server:dist', ['mocks'], function () {
         connect.server({
             root: 'target/dist'
         });


### PR DESCRIPTION
Grips now contains the server for your mocks, based on [stubby4node](https://github.com/mrak/stubby4node).
It's a highly configurable server for mocking/stubbing external systems during development.
Gript takes endpoint descriptors in the form of a YAML or JSON files that tell it how to respond to incoming requests.
For each incoming request, configured endpoints are checked in-order until a match is found.
The endpoints can contain regular expressions, any of HTTP methods, queries, headers, dynamic token interpolation, defined fake response latency and so on.
The response can be parametrized or served from a file - the possiblities are endless.
Refer to the Stubby [endpoint configuration](https://github.com/mrak/stubby4node#endpoint-configuration) section for assistance how to define your own endpoints.
By default, the `mocks` Gulp task will start together with the `server` and `server:dist` tasks.
Gript contains some simple endpoints definitions in the `mocks` and `sample_config/mocks` directory to get your started.
You can customize the mocks directory name and server ports in the `mocks` section of your `gulpfile.js`.