### PR TITLE
ts-lint and html-lint checsktyle output

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,15 @@ The number of configuration files are being used to customize the linting option
 - `.htmllintrc` contains setup for [htmllint](https://github.com/htmllint). Refer to the [options](https://github.com/htmllint/htmllint/wiki/Options) for possible settings.
 
 For your convenience, Gript contains sample configuration files for all linters in the `sample_configs` directory.
+During the linting process, Gript generates Checkstyle-like XML reports in the `target` directory:
+
+- `es-lint-result.xml`
+- `html-lint-result.xml`
+- `scss-lint-result.xml`
+- `ts-lint-result.xml`
+
+You can make use of them in you continous integration setup, like [Jenkins](https://jenkins-ci.org) for example.
+
 
 ## TypeScript compilation
 If you develop your app in the TypeScript, files will be compiled and then injected. The example setup uses [DefinitelyTyped](http://definitelytyped.org/)

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "run-sequence": "1.1.5",
     "sinon": "1.17.3",
     "vinyl-source-stream": "1.1.0",
-    "wiredep": "3.0.0"
+    "wiredep": "3.0.0",
+    "xmlbuilder": "4.2.1"
   },
   "keywords": [
     "gulp",

--- a/package/README.md
+++ b/package/README.md
@@ -249,6 +249,14 @@ The number of configuration files are being used to customize the linting option
 - `.htmllintrc` contains setup for [htmllint](https://github.com/htmllint). Refer to the [options](https://github.com/htmllint/htmllint/wiki/Options) for possible settings.
 
 For your convenience, Gript contains sample configuration files for all linters in the `sample_configs` directory.
+During the linting process, Gript generates Checkstyle-like XML reports in the `target` directory:
+
+- `es-lint-result.xml`
+- `html-lint-result.xml`
+- `scss-lint-result.xml`
+- `ts-lint-result.xml`
+
+You can make use of them in you continous integration setup, like [Jenkins](https://jenkins-ci.org) for example.
 
 ## TypeScript compilation
 If you develop your app in the TypeScript, files will be compiled and then injected. The example setup uses [DefinitelyTyped](http://definitelytyped.org/)

--- a/package/package.json
+++ b/package/package.json
@@ -65,7 +65,8 @@
     "run-sequence": "1.1.5",
     "sinon": "1.17.3",
     "vinyl-source-stream": "1.1.0",
-    "wiredep": "3.0.0"
+    "wiredep": "3.0.0",
+    "xmlbuilder": "4.2.1"
   },
   "keywords": [
     "gulp",

--- a/package/sample_configs/tslint.json
+++ b/package/sample_configs/tslint.json
@@ -4,7 +4,7 @@
     "curly": true,
     "eofline": false,
     "forin": true,
-    "indent": [true, 4],
+    "indent": [true, "spaces"],
     "label-position": true,
     "label-undefined": true,
     "max-line-length": [true, 140],

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,7 @@
     "curly": true,
     "eofline": false,
     "forin": true,
-    "indent": [true, 4],
+    "indent": [true, "spaces"],
     "label-position": true,
     "label-undefined": true,
     "max-line-length": [true, 140],


### PR DESCRIPTION
During the linting process, Gript generates Checkstyle-like XML reports in the `target` directory:

- `es-lint-result.xml`
- `html-lint-result.xml`
- `scss-lint-result.xml`
- `ts-lint-result.xml`

You can make use of them in you continous integration setup, like [Jenkins](https://jenkins-ci.org) for example.
