### PR TITLE
#24 resources and translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ The `index.html` in the `app` folder is especially important - it contains marke
 
 - JavaScript validation using [ESLint](http://eslint.org),
 - TypeScript validation ([TSLint](http://palantir.github.io/tslint/)) and incremental compilation,
-- SASS validation ([scss-lint](https://github.com/brigade/scss-lint)) and compilation,
+- scss validation ([scss-lint](https://github.com/brigade/scss-lint)) and compilation,
 - HTML validation using [htmllint](https://github.com/htmllint/),
 - unit tests performed using [Karma](https://karma-runner.github.io) and [PhantomJS](http://phantomjs.org) (tests can be written in JavaScript or TypeScript),
 - unit testing coverage metered by [Istanbul](https://github.com/gotwarlost/istanbul),
 - HTML partials pre-loading into the Angular `$templateCache`,
 - includes custom generated [Modernizr](https://modernizr.com) script
 - full concatenation/minification for all production JS and CSS files,
-- Live-reload capability: web app is auto-refreshed if HTML, TypeScript or Sass files change,
+- Live-reload capability: web app is auto-refreshed if HTML, TypeScript or scss files change,
 - watch tasks: if your source files change, they will be checked for errors, compiled and then injected into your application,
  Gript uses [Chokidar](https://github.com/paulmillr/chokidar) which notices the changes instantly, keeping the CPU usage down at the same time,
 - contains the mock server based on `YAML/JSON/JS` configuration files. Refer to the [Mock Server](#mocks) section for usage guidelines.
@@ -72,13 +72,13 @@ which means:
 - `app/app.js` or `app/App.ts` : the entry point of the [Angular](https://angularjs.org) application
 - `bower_components` : libraries downloaded by [Bower](http://bower.io/)
 - `node_modules` : tools downloaded by [npm](https://www.npmjs.org/)
-- `target/tmp` : contains generated files (compiled TypeScript, compiled Sass styles, Angular templates etc.)
+- `target/tmp` : contains generated files (compiled TypeScript, compiled scss styles, Angular templates etc.)
 - `target/dist` : contains app distribution package
 - `mocks` : contains your mock services definitions.
 - `gulpfile.js` : the build files importing the [Gulp](http://gulpjs.com) tasks defined in the `node_modules/gript`
 - `bower.json` : contains [Bower](http://bower.io) dependencies
 - `.eslint.rc.yml` : contains rules for es-linter ([ESLint](http://eslint.org)). Cascading rules configuration is possible.
-- `.scsslint.rc.yml` : contains rules for Sass linter ([scss-lint](https://github.com/brigade/scss-lint))
+- `.scsslint.rc.yml` : contains rules for scss linter ([scss-lint](https://github.com/brigade/scss-lint))
 - `tslint.json` : rules for the TypeScript linter ([TSLint](http://palantir.github.io/tslint/))
 - `.htmllint.rc` : rules for the HTML linter ([htmllint](https://github.com/htmllint))
 
@@ -205,7 +205,7 @@ command will fail, until you create your first piece of logic and its correspond
 
 ## Building your project
 
-The **default** task builds an application and then starts the development server. Your source code (TypeScript, HTML, Sass) will be watched for changes, and - if neccessary, compiled and injected into the `index.html`.
+The **default** task builds an application and then starts the development server. Your source code (TypeScript, HTML, scss) will be watched for changes, and - if neccessary, compiled and injected into the `index.html`.
 Just by running
 
     gulp
@@ -218,13 +218,13 @@ The `gulpfile.js` from Gript contains also these specific tasks:
 - **dist** : builds and minifies the application for the deployment. The application will be copied to `target/dist` directory.
 - **ts** : compiles your app TypeScript files
 - **partials** : compiles HTML partials into Angular's `$templateCache` Javascript files.
-- **styles** : compiles Sass files
-- **inject** : injects Bower dependencies, compiled HTML partials, TypeScript and Sass into your app's `index.html`. Files will be injected according to the marking in the `index.html` file. Refer to the [Files injection](#injection) section of this readme for details.
+- **styles** : compiles scss files
+- **inject** : injects Bower dependencies, compiled HTML partials, TypeScript and scss into your app's `index.html`. Files will be injected according to the marking in the `index.html` file. Refer to the [Files injection](#injection) section of this readme for details.
     - **inject-bower** : downloads and injects [Bower](http://bower.io/) dependencies
-    - **inject-styles** : compiles and injects Sass styles
+    - **inject-styles** : compiles and injects scss styles
     - **inject-partials** : compiles HTML partials into Angular's `$templateCache` and then injects them into the `index.html`
     - **inject-js** : complies the TypesScript and then injects all JavaScript files
-- **lint** : runs linters on the HTML, Sass, Javascript and TypeScript source files. Refer to the [Linting](#linting) section for possible options.
+- **lint** : runs linters on the HTML, scss, Javascript and TypeScript source files. Refer to the [Linting](#linting) section for possible options.
 	- **lint-js**
 	- **lint-scss**
 	- **lint-ts**
@@ -235,7 +235,7 @@ The `gulpfile.js` from Gript contains also these specific tasks:
     - **clean-tmp** : removes the `target/tmp` directory (all temporary generated files)
     - **clean-js** : removes the `target/tmp/js` directory (compiled TypeScript files)
     - **clean-partials** : removes the `target/tmp/partials` directory (Angular's `$templateCache` Javascript files)
-    - **clean-styles** : removes the `target/tmp/styles` directory (compiled Sass files)
+    - **clean-styles** : removes the `target/tmp/styles` directory (compiled scss files)
     - **clean-bower** : removes the `bower_components` directory
 - **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app
 - **images** : copies all image files into the `dist` directory
@@ -251,12 +251,12 @@ You can list all of the available tasks by running the command:
 
 <a name="linting"></a>
 ## Linting
-To ensure the profound checking of the code quality of your application, Gript will check all your HTML, Sass, TypeScript and JavaScript files.
+To ensure the profound checking of the code quality of your application, Gript will check all your HTML, scss, TypeScript and JavaScript files.
 The linting process is executed during the build, and is also included in the `watch` task, to re-lint the file on the fly, after you change it.
 The number of configuration files are being used to customize the linting options:
 
 - `.eslint.yml` contains configuration for the powerful JavaScript linter, the [ESLint](http://eslint.org). Refer to the [Options](http://eslint.org/docs/user-guide/configuring) section for avaialable options.
-- `.scss-lint.yml` contains configuration for Sass linter, the [scss-lint](https://github.com/brigade/scss-lint). Referer to the [Configuration](https://github.com/brigade/scss-lint#configuration) for options.
+- `.scss-lint.yml` contains configuration for scss linter, the [scss-lint](https://github.com/brigade/scss-lint). Referer to the [Configuration](https://github.com/brigade/scss-lint#configuration) for options.
 - `tslint.json` contains options for [TSLint](http://palantir.github.io/tslint/). Refer [here](http://palantir.github.io/tslint/rules/) for the description of rules.
 - `.htmllintrc` contains setup for [htmllint](https://github.com/htmllint). Refer to the [options](https://github.com/htmllint/htmllint/wiki/Options) for possible settings.
 
@@ -297,17 +297,17 @@ You can customize the minification options by modyfying the `minification` secti
 <a name="injection"></a>
 ## Compiled files injection
 
-By default, all TypeScript, Sass and HTML files will be compiled and injected into your app's `index.html` file.
+By default, all TypeScript, scss and HTML files will be compiled and injected into your app's `index.html` file.
 The `target/tmp` directory is the place for the compilation output:
 
 - `target/tmp/js` : will contain compiled TypeScript files
 - `target/tmp/partials` : will contain all HTML partials from your Angular app compiled into Angular `$templateCache`.
-- `target/tmp/styles` : will contain compiled Sass files
+- `target/tmp/styles` : will contain compiled scss files
 
 Compiled scripts and styles will then be injected into the app's `index.html` according to the injection markings:
 
 - `<!-- bower:css --><!-- endbower -->` : Bower CSS dependencies
-- `<!-- inject:css --><!-- endinject -->` : compiled Sass files
+- `<!-- inject:css --><!-- endinject -->` : compiled scss files
 - `<!-- bower:js --><!-- endbower -->` : Bower JS dependencies
 - `<!-- inject:js --><!-- endinject -->` : TypeScript files compiled into JS
 - `<!-- inject:partials --><!-- endinject -->` : HTML partials compiled into Angular's `$templateCache`.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The use of the this Gulp build tool is based on applications code being structur
     |     |---- sections
     |     |---- img
     |     |---- styles
+    |     |---- resources
     |     |---- index.html
     |     |---- app.js
     |     |---- .eslint.rc.yml
@@ -70,6 +71,7 @@ which means:
 - `app/sections` : contains the subsections of the application code
 - `app/components`: contains the components (directives, services etc.) embedded in the application
 - `app/app.js` or `app/App.ts` : the entry point of the [Angular](https://angularjs.org) application
+- `app/resources`: the place for other resources, like translation files. This will be copied to /target/dist
 - `bower_components` : libraries downloaded by [Bower](http://bower.io/)
 - `node_modules` : tools downloaded by [npm](https://www.npmjs.org/)
 - `target/tmp` : contains generated files (compiled TypeScript, compiled scss styles, Angular templates etc.)

--- a/app/App.ts
+++ b/app/App.ts
@@ -1,11 +1,14 @@
 /// <reference path="../bower_components/DefinitelyTyped/angularjs/angular.d.ts" />
 /// <reference path="../bower_components/DefinitelyTyped/angularjs/angular-route.d.ts" />
+/// <reference path="../bower_components/DefinitelyTyped/angular-translate/angular-translate.d.ts" />
 /// <reference path="Routes.ts" />
+/// <reference path="Locales.ts" />
 /// <reference path='sections/portfolio/PortfolioModule.ts'/>
 
 module App {
     'use strict';
 
-    var app = angular.module('gript', ['ngRoute', 'ui.bootstrap', 'picardy.fontawesome', 'portfolio']);
+    var app = angular.module('gript', ['ngRoute', 'ui.bootstrap', 'picardy.fontawesome', 'pascalprecht.translate', 'portfolio']);
     app.config(['$routeProvider', App.Routes.configureRoutes]);
+    app.config(['$translateProvider', App.Locales.configureLocales]);
 }

--- a/app/Locales.ts
+++ b/app/Locales.ts
@@ -1,0 +1,16 @@
+/// <reference path="../bower_components/DefinitelyTyped/angularjs/angular.d.ts" />
+/// <reference path="../bower_components/DefinitelyTyped/angular-translate/angular-translate.d.ts" />
+module App {
+    export class Locales {
+        static $inject = ['$translateProvider', '$translateStaticFilesLoaderProvider'];
+
+        static configureLocales($translateProvider:angular.translate.ITranslateProvider) {
+            $translateProvider.useStaticFilesLoader({
+                prefix: 'resources/locale-',
+                suffix: '.json'
+            });
+            $translateProvider.useSanitizeValueStrategy('escaped');
+            $translateProvider.preferredLanguage('en_US');
+        }
+    }
+}

--- a/app/components/navigation/NavigationController.ts
+++ b/app/components/navigation/NavigationController.ts
@@ -1,24 +1,39 @@
 /// <reference path='../../../bower_components/DefinitelyTyped/angularjs/angular.d.ts' />
+/// <reference path='../../../bower_components/DefinitelyTyped/angular-translate/angular-translate.d.ts' />
 
 module Portfolio {
 
     interface INavigationController {
-        isActive(path: String) : boolean;
+        isActive(path: string) : boolean;
+        toggleLanguage(language: string): void;
+        isLanguageActive(language: string) : boolean;
     }
 
     export class NavigationController implements INavigationController {
         'use strict';
 
-        static $inject = ['$location'];
+        static $inject = ['$location', '$translate'];
 
         location: ng.ILocationService;
+        translate: angular.translate.ITranslateService;
 
-        constructor(private $location: ng.ILocationService) {
+        constructor(private $location: ng.ILocationService, private $translate: angular.translate.ITranslateService) {
             this.location = $location;
+            this.translate = $translate;
+            this.toggleLanguage('en_US');
         }
 
-        isActive(path: String):boolean {
+        isActive(path: string):boolean {
             return path === this.location.path();
         }
+
+        toggleLanguage(language: string):void {
+            this.translate.use(language);
+        }
+
+        isLanguageActive(language: string):boolean {
+            return this.translate.use() === language;
+        }
+
     }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -20,15 +20,21 @@
 </head>
 
 <body class="no-select">
-    <nav class="navbar navbar-default navbar-fixed-top" role="navigation" ng-controller="navigationController as vm">
-        <div class="container-fluid">
-            <div class="collapse navbar-collapse" data-collapse="vm.navbar">
-                <ul class="nav navbar-nav">
-                    <li ng-class="{ active: vm.isActive('/welcome')}"><a tabindex="1" href="#welcome" title="Home"><fa name="home"></fa></a></li>
-                    <li ng-class="{ active: vm.isActive('/portfolio')}"><a href="#portfolio" tabindex="2">Portfolio</a></li>
-                    <li ng-class="{ active: vm.isActive('/empty')}"><a href="#empty" tabindex="3">Empty</a></li>
-                </ul>
-            </div>
+    <nav class="navbar navbar-default" role="navigation" ng-controller="navigationController as vm">
+        <div class="collapse navbar-collapse" data-collapse="vm.navbar">
+            <ul class="nav navbar-nav navbar-left">
+                <li ng-class="{ active: vm.isActive('/welcome')}"><a tabindex="1" href="#welcome" title="{{'tab.home' | translate}}"><fa name="home"></fa></a></li>
+                <li ng-class="{ active: vm.isActive('/portfolio')}"><a href="#portfolio" tabindex="2">{{'tab.portfolio' | translate}}</a></li>
+                <li ng-class="{ active: vm.isActive('/empty')}"><a href="#empty" tabindex="3">{{'tab.empty' | translate}}</a></li>
+            </ul>
+            <ul class="nav navbar-nav navbar-right nav-pills">
+                <li ng-class="{ active: vm.isLanguageActive('en_US')}">
+                    <a ng-click="vm.toggleLanguage('en_US')">EN</a>
+                </li>
+                <li ng-class="{ active: vm.isLanguageActive('pl_PL')}">
+                    <a ng-click="vm.toggleLanguage('pl_PL')">PL</a>
+                </li>
+            </ul>
         </div>
     </nav>
 

--- a/app/resources/locale-en_US.json
+++ b/app/resources/locale-en_US.json
@@ -1,0 +1,9 @@
+{
+  "tab.home": "Home",
+  "tab.portfolio": "Portfolio",
+  "tab.empty": "Empty",
+  "btn.toggle": "EN/PL",
+  "home.header": "GRIPT sample (Angular + TypeScript + Sass)",
+  "portfolio.header": "Portfolio example",
+  "portfolio.info": "Portfolio included as an example in Gript sample app."
+}

--- a/app/resources/locale-pl_PL.json
+++ b/app/resources/locale-pl_PL.json
@@ -1,0 +1,9 @@
+{
+  "tab.home": "Start",
+  "tab.portfolio": "Portfolio",
+  "tab.empty": "Puste",
+  "btn.toggle": "EN/PL",
+  "home.header": "GRIPT przykład  (Angular + TypeScript + Sass)",
+  "portfolio.header": "Przykład Portfolio",
+  "portfolio.info": "Portfolio w przykładowej aplikacji Gript."
+}

--- a/app/sections/portfolio/portfolio.html
+++ b/app/sections/portfolio/portfolio.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <div id="portfolio">
-    <h1 class="header-dual">Portfolio <span> - example</span></h1>
-    <div class="text-box" title="a litte story about the example">
-        <p>Portfolio included as an example in Gript sample app.</p>
+    <h1 class="header-dual">{{'portfolio.header' | translate}}</h1>
+    <div class="text-box">
+        <p>{{'portfolio.info' | translate}}</p>
     </div>
 
     <div class="table-box">

--- a/app/sections/welcome/welcome.html
+++ b/app/sections/welcome/welcome.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <div id="welcome" class="module">
-    <div class="browser-warning">Too old browser for Angular Material</div>
+    <div class="browser-warning">Your browser is too old</div>
 
     <div class="no-browser-warning jumbotron">
-        <h1>GRIPT sample (Angular + TypeScript + Sass)</h1>
+        <h1>{{'home.header' | translate}}</h1>
             <picture>
                 <source srcset="img/angularjs.png" media="(min-width: 1000px)">
                 <source srcset="img/angularjs_m.png, img/angularjs.png 2x" media="(min-width: 768px)">

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,8 @@
     "angular-resource": "~1.4",
     "angular-route": "~1.4",
     "angular-sanitize": "~1.4",
+    "angular-translate": "~2.9.1",
+    "angular-translate-loader-static-files": "~2.9.1",
     "bootstrap-sass-official": "~3.3"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gript",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Gulp Build Setup",
   "dependencies": {
     "bower": "1.7.7",

--- a/package/README.md
+++ b/package/README.md
@@ -24,14 +24,14 @@ The `index.html` in the `app` folder is especially important - it contains marke
 
 - JavaScript validation using [ESLint](http://eslint.org),
 - TypeScript validation ([TSLint](http://palantir.github.io/tslint/)) and incremental compilation,
-- SASS validation ([scss-lint](https://github.com/brigade/scss-lint)) and compilation,
+- scss validation ([scss-lint](https://github.com/brigade/scss-lint)) and compilation,
 - HTML validation using [htmllint](https://github.com/htmllint/),
 - unit tests performed using [Karma](https://karma-runner.github.io) and [PhantomJS](http://phantomjs.org) (tests can be written in JavaScript or TypeScript),
 - unit testing coverage metered by [Istanbul](https://github.com/gotwarlost/istanbul),
 - includes custom generated [Modernizr](https://modernizr.com) script
 - HTML partials pre-loading into the Angular `$templateCache`,
 - full concatenation/minification for all production JS and CSS files,
-- Live-reload capability: web app is auto-refreshed if HTML, TypeScript or Sass files change,
+- Live-reload capability: web app is auto-refreshed if HTML, TypeScript or scss files change,
 - watch tasks: if your source files change, they will be checked for errors, compiled and then injected into your application,
  Gript uses [Chokidar](https://github.com/paulmillr/chokidar) which notices the changes instantly, keeping the CPU usage down at the same time,
 - contains the mock server based on `YAML/JSON/JS` configuration files. Refer to the [Mock Server](#mocks) section for usage guidelines.
@@ -72,13 +72,13 @@ which means:
 - `app/app.js` or `app/App.ts` : the entry point of the [Angular](https://angularjs.org) application
 - `bower_components` : libraries downloaded by [Bower](http://bower.io/)
 - `node_modules` : tools downloaded by [npm](https://www.npmjs.org/)
-- `target/tmp` : contains generated files (compiled TypeScript, compiled Sass styles, Angular templates etc.)
+- `target/tmp` : contains generated files (compiled TypeScript, compiled scss styles, Angular templates etc.)
 - `target/dist` : contains app distribution package
 - `mocks` : contains your mock services definitions.
 - `gulpfile.js` : the build files importing the [Gulp](http://gulpjs.com) tasks defined in the `node_modules/gript`
 - `bower.json` : contains [Bower](http://bower.io) dependencies
 - `.eslint.rc.yml` : contains rules for es-linter ([ESLint](http://eslint.org)). Cascading rules configuration is possible.
-- `.scsslint.rc.yml` : contains rules for Sass linter ([scss-lint](https://github.com/brigade/scss-lint))
+- `.scsslint.rc.yml` : contains rules for scss linter ([scss-lint](https://github.com/brigade/scss-lint))
 - `tslint.json` : rules for the TypeScript linter ([TSLint](http://palantir.github.io/tslint/))
 - `.htmllint.rc` : rules for the HTML linter ([htmllint](https://github.com/htmllint))
 
@@ -205,7 +205,7 @@ command will fail, until you create your first piece of logic and its correspond
 
 ## Building your project
 
-The **default** task builds an application and then starts the development server. Your source code (TypeScript, HTML, Sass) will be watched for changes, and - if neccessary, compiled and injected into the `index.html`.
+The **default** task builds an application and then starts the development server. Your source code (TypeScript, HTML, scss) will be watched for changes, and - if neccessary, compiled and injected into the `index.html`.
 Just by running
 
     gulp
@@ -218,13 +218,13 @@ The `gulpfile.js` from Gript contains also these specific tasks:
 - **dist** : builds and minifies the application for the deployment. The application will be copied to `target/dist` directory.
 - **ts** : compiles your app TypeScript files
 - **partials** : compiles HTML partials into Angular's `$templateCache` Javascript files.
-- **styles** : compiles Sass files
-- **inject** : injects Bower dependencies, compiled HTML partials, TypeScript and Sass into your app's `index.html`. Files will be injected according to the marking in the `index.html` file. Refer to the [Files injection](#injection) section of this readme for details.
+- **styles** : compiles scss files
+- **inject** : injects Bower dependencies, compiled HTML partials, TypeScript and scss into your app's `index.html`. Files will be injected according to the marking in the `index.html` file. Refer to the [Files injection](#injection) section of this readme for details.
     - **inject-bower** : downloads and injects [Bower](http://bower.io/) dependencies
-    - **inject-styles** : compiles and injects Sass styles
+    - **inject-styles** : compiles and injects scss styles
     - **inject-partials** : compiles HTML partials into Angular's `$templateCache` and then injects them into the `index.html`
     - **inject-js** : complies the TypesScript and then injects all JavaScript files
-- **lint** : runs linters on the HTML, Sass, Javascript and TypeScript source files. Refer to the [Linting](#linting) section for possible options.
+- **lint** : runs linters on the HTML, scss, Javascript and TypeScript source files. Refer to the [Linting](#linting) section for possible options.
 	- **lint-js**
 	- **lint-scss**
 	- **lint-ts**
@@ -235,7 +235,7 @@ The `gulpfile.js` from Gript contains also these specific tasks:
     - **clean-tmp** : removes the `target/tmp` directory (all temporary generated files)
     - **clean-js** : removes the `target/tmp/js` directory (compiled TypeScript files)
     - **clean-partials** : removes the `target/tmp/partials` directory (Angular's `$templateCache` Javascript files)
-    - **clean-styles** : removes the `target/tmp/styles` directory (compiled Sass files)
+    - **clean-styles** : removes the `target/tmp/styles` directory (compiled scss files)
     - **clean-bower** : removes the `bower_components` directory
 - **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app
 - **images** : copies all image files into the `dist` directory
@@ -251,12 +251,12 @@ You can list all of the available tasks by running the command:
 
 <a name="linting"></a>
 ## Linting
-To ensure the profound checking of the code quality of your application, Gript will check all your HTML, Sass, TypeScript and JavaScript files.
+To ensure the profound checking of the code quality of your application, Gript will check all your HTML, scss, TypeScript and JavaScript files.
 The linting process is executed during the build, and is also included in the `watch` task, to re-lint the file on the fly, after you change it.
 The number of configuration files are being used to customize the linting options:
 
 - `.eslint.yml` contains configuration for the powerful JavaScript linter, the [ESLint](http://eslint.org). Refer to the [Options](http://eslint.org/docs/user-guide/configuring) section for avaialable options.
-- `.scss-lint.yml` contains configuration for Sass linter, the [scss-lint](https://github.com/brigade/scss-lint). Referer to the [Configuration](https://github.com/brigade/scss-lint#configuration) for options.
+- `.scss-lint.yml` contains configuration for scss linter, the [scss-lint](https://github.com/brigade/scss-lint). Referer to the [Configuration](https://github.com/brigade/scss-lint#configuration) for options.
 - `tslint.json` contains options for [TSLint](http://palantir.github.io/tslint/). Refer [here](http://palantir.github.io/tslint/rules/) for the description of rules.
 - `.htmllintrc` contains setup for [htmllint](https://github.com/htmllint). Refer to the [options](https://github.com/htmllint/htmllint/wiki/Options) for possible settings.
 
@@ -297,17 +297,17 @@ You can customize the minification options by modyfying the `minification` secti
 <a name="injection"></a>
 ## Compiled files injection
 
-By default, all TypeScript, Sass and HTML files will be compiled and injected into your app's `index.html` file.
+By default, all TypeScript, scss and HTML files will be compiled and injected into your app's `index.html` file.
 The `target/tmp` directory is the place for the compilation output:
 
 - `target/tmp/js` : will contain compiled TypeScript files
 - `target/tmp/partials` : will contain all HTML partials from your Angular app compiled into Angular `$templateCache`.
-- `target/tmp/styles` : will contain compiled Sass files
+- `target/tmp/styles` : will contain compiled scss files
 
 Compiled scripts and styles will then be injected into the app's `index.html` according to the injection markings:
 
 - `<!-- bower:css --><!-- endbower -->` : Bower CSS dependencies
-- `<!-- inject:css --><!-- endinject -->` : compiled Sass files
+- `<!-- inject:css --><!-- endinject -->` : compiled scss files
 - `<!-- bower:js --><!-- endbower -->` : Bower JS dependencies
 - `<!-- inject:js --><!-- endinject -->` : TypeScript files compiled into JS
 - `<!-- inject:partials --><!-- endinject -->` : HTML partials compiled into Angular's `$templateCache`.

--- a/package/README.md
+++ b/package/README.md
@@ -48,6 +48,7 @@ The use of the this Gulp build tool is based on applications code being structur
     |     |---- sections
     |     |---- img
     |     |---- styles
+    |     |---- resources
     |     |---- index.html
     |     |---- app.js
     |     |---- .eslint.rc.yml
@@ -70,6 +71,7 @@ which means:
 - `app/sections` : contains the subsections of the application code
 - `app/components`: contains the components (directives, services etc.) embedded in the application
 - `app/app.js` or `app/App.ts` : the entry point of the [Angular](https://angularjs.org) application
+- `app/resources`: the place for other resources, like translation files. This will be copied to /target/dist
 - `bower_components` : libraries downloaded by [Bower](http://bower.io/)
 - `node_modules` : tools downloaded by [npm](https://www.npmjs.org/)
 - `target/tmp` : contains generated files (compiled TypeScript, compiled scss styles, Angular templates etc.)

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gript",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Gulp Build Setup",
   "dependencies": {
     "bower": "1.7.7",

--- a/tasks/build.gulp.js
+++ b/tasks/build.gulp.js
@@ -120,7 +120,14 @@ module.exports = function (gulp) {
             .pipe(size());
     });
 
-    gulp.task('build', ['version', 'inject', 'images', 'fonts', 'lint-js'], function (callback) {
+    gulp.task('resources', function () {
+        return gulp.src('app/resources/**/*')
+            .pipe(gulp.dest('target/dist/resources'))
+            .pipe(gulp.dest('target/tmp/resources'))
+            .pipe(size());
+    });
+
+    gulp.task('build', ['version', 'inject', 'images', 'fonts', 'resources', 'lint-js'], function (callback) {
         callback();
     });
 

--- a/tasks/lint.gulp.js
+++ b/tasks/lint.gulp.js
@@ -19,10 +19,10 @@ module.exports = function (gulp) {
         sassReportFilename = 'target/scss-lint-result.xml',
         tsLintReportFile,
         htmlLintReportFile,
-        sassLintReportFile,
+        scssLintReportFile,
         htmlReport,
         tsReport,
-        sassReport,
+        scssReport,
         projectRoot = process.cwd(),
         reportIssues = function (filename, issues, report, msgProperty, lineProperty, columnProperty) {
             var fileElement;
@@ -49,7 +49,7 @@ module.exports = function (gulp) {
             reportIssues(filepath, issues, htmlReport, 'msg', 'line', 'column');
         },
         reportSassIssues = function (file) {
-            reportIssues(file.path, file.scsslint.issues, sassReport, 'reason', 'line', 'column');
+            reportIssues(file.path, file.scsslint.issues, scssReport, 'reason', 'line', 'column');
         };
 
     gulp.task('lint', ['lint-js', 'lint-ts', 'lint-scss', 'lint-html']);
@@ -70,8 +70,8 @@ module.exports = function (gulp) {
     gulp.task('lint-scss', function () {
         var stream;
         fs.unlink(sassReportFilename, function () {
-            sassLintReportFile = fs.createWriteStream(sassReportFilename);
-            sassReport = xml.create('checkstyle');
+            scssLintReportFile = fs.createWriteStream(sassReportFilename);
+            scssReport = xml.create('checkstyle');
             stream = gulp.src(scssFiles)
                 .pipe(scsslint({
                     config: path.join(projectRoot, '.scss-lint.yml'),
@@ -79,8 +79,8 @@ module.exports = function (gulp) {
                 }));
 
             stream.on('end', function () {
-                sassLintReportFile.write(sassReport.doc().end({pretty: true}));
-                sassLintReportFile.end();
+                scssLintReportFile.write(scssReport.doc().end({pretty: true}));
+                scssLintReportFile.end();
             });
 
         });


### PR DESCRIPTION
Added support for resource folder (useful for angular-translate for example). Resource folder will be copied to /target/tmp and /target/dist. Example TypeScript app updated with the angular-translate support to demonstrate the use of resource folders:

![screen shot 2016-02-18 at 09 53 28](https://cloud.githubusercontent.com/assets/2701356/13138315/b7c926ec-d626-11e5-8e10-8d4c0eeff1e1.png)


