### PR TITLE
Stringify config file path

### DIFF
--- a/tasks/lint.gulp.js
+++ b/tasks/lint.gulp.js
@@ -74,7 +74,7 @@ module.exports = function (gulp) {
             scssReport = xml.create('checkstyle');
             stream = gulp.src(scssFiles)
                 .pipe(scsslint({
-                    config: path.join(projectRoot, '.scss-lint.yml'),
+                    config: JSON.stringify(path.join(projectRoot, '.scss-lint.yml')),
                     customReport: reportSassIssues
                 }));
 
@@ -127,5 +127,3 @@ module.exports = function (gulp) {
             }));
     });
 };
-
-


### PR DESCRIPTION
If the path of the SCSS-lint config file contains spaces (e.g. on Jenkins), it needs to be quoted, or the Ruby program will fail.
This pull request simply quotes the config file.