### PR TITLE
Added support for running unit tests and test coverage in a Jenkins environment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -114,7 +114,7 @@ gulp.task('create-package', ['dist'], function () {
         .pipe(gulp.dest('target/gript/sample_configs'));
     gulp.src(['package/img/*.*'])
         .pipe(gulp.dest('target/gript/img'));
-    gulp.src(['package/*'])
+    gulp.src(['package/*', '!package/karma.conf.js'])
         .pipe(gulp.dest('target/gript'));
     gulp.src(['package/karma.conf.js'])
         .pipe(gulp.dest('target/gript/tasks'));

--- a/package/karma.conf.js
+++ b/package/karma.conf.js
@@ -5,18 +5,22 @@ module.exports = function (config) {
     config.set({
         basePath: '../../../',
         frameworks: ['jasmine'],
-        files: ['**/*/*_test.js'],
-        exclude: ['**/*/bower_components'],
         preprocessors: {
-            'app/!(bower_components)/!(patch)/**/!(*_test).js': ['coverage']
+            'app/!(patch)/**/!(*_test).js': ['coverage'],
+            'target/tmp/js/**/!(all|*_test).js': ['coverage']
         },
         reporters: ['progress', 'junit', 'coverage'],
         junitReporter: {
-            outputFile: 'target/test-results.xml'
+            outputDir: 'target',
+            outputFile: 'test-results.xml',
+            suite: '',
+            useBrowserName: false
         },
         coverageReporter: {
             type: 'cobertura',
-            dir: 'target/coverage/'
+            dir: 'target',
+            file: 'cobertura-coverage.xml',
+            subdir: '.'
         },
         port: 9876,
         colors: true,

--- a/tasks/build.gulp.js
+++ b/tasks/build.gulp.js
@@ -86,15 +86,7 @@ module.exports = function (gulp) {
     gulp.task('inject-js', function () {
         return gulp.src('app/index.html')
             .pipe(gulpInject(
-                gulp.src(['target/tmp/js/**/*.js', '!target/tmp/js/**/*test.js'])
-                    .pipe(naturalSort())
-                    .pipe(angularFilesort()),
-                {
-                    relative: true
-                }
-            ))
-            .pipe(gulpInject(
-                gulp.src(['app/**/*.js', '!app/**/*Test.js', '!app/**/*test.js'])
+                gulp.src(['app/**/*.js', '!app/**/*Test.js', '!app/**/*test.js', 'target/tmp/js/all.js'])
                     .pipe(naturalSort())
                     .pipe(angularFilesort()),
                 {
@@ -136,4 +128,3 @@ module.exports = function (gulp) {
         util.log(util.colors.blue.bold("Gript building " + json.name + " " + json.version + "..."));
     });
 };
-

--- a/tasks/karma.conf.js
+++ b/tasks/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
         coverageReporter: {
             type: 'cobertura',
             dir: 'target',
-            file: 'coverage-results.xml',
+            file: 'cobertura-coverage.xml',
             subdir: '.'
         },
         port: 9876,

--- a/tasks/ts.gulp.js
+++ b/tasks/ts.gulp.js
@@ -20,7 +20,7 @@ module.exports = function (gulp) {
         };
 
     /**
-     * compile all typescript files and sourcemaps from /app and output them to /target/tmp
+     * compile all typescript files and sourcemaps from /app and output them to /target/tmp/js/all.js
      */
     gulp.task('ts', function (callback) {
         sequence('compile', 'test', callback);
@@ -42,15 +42,14 @@ module.exports = function (gulp) {
     });
 
     /**
-     * compile all typescript test files and sourcemaps from /app and output them to /target/tmp
+     * compile all typescript files from /app and output them to /target/tmp/js as individual files for unit testing
      */
     gulp.task('compile-tests', function () {
         var options = _.merge({}, defaults, gulp.config.typeScript),
             tsProject = ts.createProject({
-                compilerOptions: options,
-                out: 'all_test.js'
+                compilerOptions: options
             }),
-            tsResult = gulp.src(['app/**/*Test.ts', 'app/**/*test.ts'])
+            tsResult = gulp.src(['app/**/*.ts'])
                 .pipe(ts(tsProject));
 
         return tsResult.js


### PR DESCRIPTION
Unit test results are written to `target/test-results.xml`.
TypeScript files are compiled individually for unit testing in order to get proper per-file code coverage.
Coverage results are written to `target/cobertura-coverage.xml`.
