### PR TITLE
Added missing modernizr.js to 'inject-js'

### DIFF
--- a/tasks/build.gulp.js
+++ b/tasks/build.gulp.js
@@ -86,7 +86,7 @@ module.exports = function (gulp) {
     gulp.task('inject-js', function () {
         return gulp.src('app/index.html')
             .pipe(gulpInject(
-                gulp.src(['app/**/*.js', '!app/**/*Test.js', '!app/**/*test.js', 'target/tmp/js/all.js'])
+                gulp.src(['app/**/*.js', '!app/**/*Test.js', '!app/**/*test.js', 'target/tmp/js/all.js', 'target/tmp/js/modernizr.js'])
                     .pipe(naturalSort())
                     .pipe(angularFilesort()),
                 {


### PR DESCRIPTION
Hi @jotka 

Thanks for the release - unfortunately I screwed up, so modernizr.js was not injected anymore. I didn't realize that it is built and injected together with our own code.
I have fixed it now.