### PR TITLE
Adding karma plugins to karma.conf.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "karma-angular-filesort": "1.0.1",
     "karma-junit-reporter": "0.3.8",
     "karma-phantomjs-launcher": "0.2.3",
+	"karma-ng-html2js-preprocessor": "0.2.1",
     "phantomjs": "1.9.19",
     "karma-sinon": "1.0.4",
     "karma-spec-reporter": "0.0.23",

--- a/package/package.json
+++ b/package/package.json
@@ -59,6 +59,7 @@
     "karma-angular-filesort": "1.0.1",
     "karma-junit-reporter": "0.3.8",
     "karma-phantomjs-launcher": "0.2.3",
+	"karma-ng-html2js-preprocessor": "0.2.1",
     "lodash": "4.3.0",
     "phantomjs": "1.9.19",
     "karma-sinon": "1.0.4",

--- a/tasks/karma.conf.js
+++ b/tasks/karma.conf.js
@@ -28,6 +28,14 @@ module.exports = function (config) {
                 'target/tmp/js/**/*.js'
             ]
         },
+        plugins: [
+            'karma-jasmine',
+            'karma-angular-filesort',
+            'karma-phantomjs-launcher',
+            'karma-junit-reporter',
+            'karma-coverage',
+            'karma-ng-html2js-preprocessor'
+        ],
         port: 9876,
         colors: true,
         logLevel: config.LOG_INFO,


### PR DESCRIPTION
Npm will not install dependencies in the child (gript) when they are already installed in a parent, this makes karma not able to find the plugins.
This PR, ensures that plugins are loaded from root.