### PR TITLE
Making config task not create a new module

### DIFF
--- a/tasks/config.gulp.js
+++ b/tasks/config.gulp.js
@@ -8,7 +8,8 @@ module.exports = function (gulp) {
 
         gulp.src(src)
             .pipe(ngConstant({
-                name: gulp.config.app.module
+                name: gulp.config.app.module,
+                deps: false
             }))
             .pipe(gulp.dest('target/tmp/js'));
     });


### PR DESCRIPTION
The config task will create a new module with the same name as the gulp.config.app.module configuration. This however does not play nice when using an app.js for bootstrapping angular.
This PR will make the config add the configuration to the existing module.