### PR TITLE
app.manifest not included in pre-release and release

### DIFF
--- a/tasks/dist.gulp.js
+++ b/tasks/dist.gulp.js
@@ -37,18 +37,21 @@ module.exports = function (gulp) {
         };
 
     gulp.task('dist', function (callback) {
-        sequence('clean', 'appcache', callback);
+        sequence('clean', ['appcache-create','appcache-include'], callback);
     });
 
-    gulp.task('appcache', ['minify'], function () {
-        gulp.src(['target/dist/**/*'])
+    gulp.task('appcache-create', ['minify'], function () {
+        return gulp.src(['target/dist/**/*'])
             .pipe(appcache({
                 filename: 'app.manifest',
                 exclude: ['app.manifest', 'index.html'],
                 timestamp: true
             }))
             .pipe(gulp.dest('target/dist'));
-        gulp.src(['target/dist/index.html'])
+    });
+
+    gulp.task('appcache-include', ['minify'], function () {
+        return gulp.src(['target/dist/index.html'])
             .pipe(replace(/<html /, '<html manifest="app.manifest" '))
             .pipe(gulp.dest('target/dist'));
     });
@@ -69,5 +72,3 @@ module.exports = function (gulp) {
             .pipe(size());
     });
 };
-
-

--- a/tasks/release.gulp.js
+++ b/tasks/release.gulp.js
@@ -5,7 +5,7 @@ module.exports = function (gulp) {
     var release = require('gulp-git-release');
 
     gulp.task('prerelease', ['dist'], function () {
-        gulp.src('target/dist/**').pipe(release({
+        return gulp.src('target/dist/**').pipe(release({
             prefix: 'target/dist',
             release: false,
             repository: gulp.config.repository
@@ -13,7 +13,7 @@ module.exports = function (gulp) {
     });
 
     gulp.task('release', ['dist'], function () {
-        gulp.src('target/dist/**').pipe(release({
+        return gulp.src('target/dist/**').pipe(release({
             prefix: 'target/dist',
             release: true,
             repository: gulp.config.repository


### PR DESCRIPTION
The app.manifest seems to be missing from the files which are distributed to Git repository as part of release. It turns out this is because the "appcache" task is actually finished before the body is executed because the task did not utilize callback nor returning any promise or event stream. The meant that the release task started running before the "body" of the appcache task had run.

Actually the "prerelease" and "release" tasks also did not return anything but since those were the last to be executed it caused no problems (other than the output actually showing the task to finish before it was run).