### PR TITLE
fonts scan dir can be now customized in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,11 @@ This `sample_configs/gulpfile.js` can be used as a starter for your project. Thi
 				   'setClasses'
 			   ],
 			   'feature-detects': []
-		   }
+		   },
+           fontsScan: [
+               'bower_components/font-awesome', 
+               'bower_components/bootstrap-sass-official'
+           ]
 	   };
 ```
 
@@ -249,7 +253,7 @@ The `gulpfile.js` from Gript contains also these specific tasks:
     - **clean-partials** : removes the `target/tmp/partials` directory (Angular's `$templateCache` Javascript files)
     - **clean-styles** : removes the `target/tmp/styles` directory (compiled scss files)
     - **clean-bower** : removes the `bower_components` directory
-- **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app
+- **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app. It will search the whole `bower_components` directory, unless you configure it otherwise in the `fontsScan` array in the config section of the `gulpfile.js`.
 - **images** : copies all image files into the `dist` directory
 - **watch** : watches the source code for changes and runs the relevant task(s) whenever something changes
 - **server** : starts a development server

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,11 @@ gulp.config = {
             mangle: true,
             preserveComments: false
         }
-    }
+    },
+    fontsScan: [
+        'bower_components/font-awesome',
+        'bower_components/bootstrap-sass-official'
+    ]
 };
 
 // verify that the build setup can produce the expected artifacts

--- a/package/README.md
+++ b/package/README.md
@@ -191,7 +191,11 @@ This `sample_configs/gulpfile.js` can be used as a starter for your project. Thi
 				   'setClasses'
 			   ],
 			   'feature-detects': []
-		   }
+		   },
+		   fontsScan: [
+               'bower_components/font-awesome', 
+               'bower_components/bootstrap-sass-official'
+           ]
 	   };
 ```
 
@@ -248,7 +252,7 @@ The `gulpfile.js` from Gript contains also these specific tasks:
     - **clean-partials** : removes the `target/tmp/partials` directory (Angular's `$templateCache` Javascript files)
     - **clean-styles** : removes the `target/tmp/styles` directory (compiled scss files)
     - **clean-bower** : removes the `bower_components` directory
-- **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app
+- **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app. It will search the whole `bower_components` directory, unless you configure it otherwise in the `fontsScan` array in the config section of the `gulpfile.js`.
 - **images** : copies all image files into the `dist` directory
 - **watch** : watches the source code for changes and runs the relevant task(s) whenever something changes
 - **server** : starts a development server

--- a/package/sample_configs/gulpfile.js
+++ b/package/sample_configs/gulpfile.js
@@ -73,5 +73,9 @@ gulp.config = {
             'setClasses'
         ],
         'feature-detects': []
-    }
+    },
+    fontsScan: [
+        'bower_components/font-awesome',
+        'bower_components/bootstrap-sass-official'
+    ]
 };

--- a/tasks/build.gulp.js
+++ b/tasks/build.gulp.js
@@ -97,7 +97,13 @@ module.exports = function (gulp, paths) {
     });
 
     gulp.task('fonts', function () {
-        return gulp.src(path.join(paths.bower, '**/*'))
+        var foldersToScan = gulp.config.hasOwnProperty('fontsScan') ? gulp.config.fontsScan : [ paths.bower ],
+            folders = foldersToScan.map(function (folder) {
+                util.log('extracting fonts from ' + folder);
+                return path.join(projectRoot, folder, '**/*');
+            });
+
+        return gulp.src(folders)
             .pipe(filter(paths.src.fonts))
             .pipe(flatten())
             .pipe(gulp.dest(paths.target.dist.fonts))


### PR DESCRIPTION
- **fonts** : searches for all `eot`, `ttf`, `woff` , `woff2` files, flattens the directory structure and copies them into your app. It will search the whole `bower_components` directory, unless you configure it otherwise in the `fontsScan` array in the config section of the `gulpfile.js`.