### PR TITLE
 Make tslint.json optional #46

### DIFF
--- a/tasks/check.gulp.js
+++ b/tasks/check.gulp.js
@@ -30,7 +30,6 @@ module.exports = function (gulp, paths) {
         check('app');
         check('app.module');
 
-        checkFile(path.join(projectRoot, paths.linters.scss));
         checkFile(path.join(projectRoot, paths.linters.eslint));
     });
 };


### PR DESCRIPTION
actually, from now on, Gript will continue with the default rules and issue a warning if any of the linter configuration is missing:

 - .scss-lint.yml
 - .htmllintrc
 - tslint.json