### PR TITLE
Renamed phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "license-checker": "5.0",
     "lodash": "4.3.0",
     "merge-stream": "1.0.0",
-    "phantomjs": "2.1",
+    "phantomjs-prebuilt": "2.1.7",
     "protractor": "3.0.0",
     "run-sequence": "1.1.5",
     "sinon": "1.17.3",


### PR DESCRIPTION
The logs warn about this: 
npm WARN deprecated phantomjs@2.1.7: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'