### PR TITLE
Enabled custom params when starting protractor

### DIFF
--- a/e2e-tests/portfolio_e2e-test.js
+++ b/e2e-tests/portfolio_e2e-test.js
@@ -4,7 +4,8 @@ describe('sample-application-e2e-test', function () {
     describe('Portfolio', function () {
 
         it('should render portfolio when user navigates to /portfolio', function () {
-            browser.get('http://localhost:8080/#!/portfolio');
+            //BaseUrl is provided on startup of protractor, only relative path is needed here
+            browser.get('/#/portfolio');
             expect(element.all(by.css('.header-dual')).first().getText())
                 .toMatch(/Portfolio/);
         });

--- a/tasks/e2e-test.gulp.js
+++ b/tasks/e2e-test.gulp.js
@@ -3,7 +3,15 @@
 module.exports = function (gulp, paths) {
 
     var protractor = require('gulp-protractor').protractor,
-        update = require('gulp-protractor').webdriver_update;
+        update = require('gulp-protractor').webdriver_update,
+        params = process.argv,
+        defaultBaseUrl = ['--baseUrl', 'http://localhost:8080'],
+        args = params.length > 3 ? params.slice(3, params.length) : defaultBaseUrl;
+
+    //Add baseUrl param if not in provided custom params
+    args = args.concat(defaultBaseUrl.filter(function () {
+        return args.indexOf('--baseUrl') < 0;
+    }));
 
     // Downloads the selenium webdriver
     gulp.task('webdriver_update', update);
@@ -12,7 +20,7 @@ module.exports = function (gulp, paths) {
         gulp.src(paths.protractor.tests)
             .pipe(protractor({
                 configFile: paths.protractor.config,
-                args: ['--baseUrl', 'http://localhost:8080']
+                args: args
             }))
             .on('error', function (error) {
                 console.error(String(error));


### PR DESCRIPTION
i.e. using 'gulp protractor --directConnect true --baseUrl http://localhost:8081' will allow you to start protractor with parameters that will overwrite any params provided in protractor-config.js. Comes in handy if you would like to enable a remote selenium server to execute your e2e tests. Backwards compatible as default baseUrl is still set to http://localhost:8080.

Fixed portfolio e2e-test, that was broken due to change in path.