### PR TITLE
appcache manifest generation made optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ This `sample_configs/gulpfile.js` can be used as a starter for your project. Thi
        // Set the config to use across the gulp build
        gulp.config = {
            repository: 'http://git.nykreditnet.net/scm/dist/xpa-no-specified-project.git',
+           skipAppCacheGeneration: true,
            app: {
                module: 'yourApp',
                constantsFile: 'app/constants.json'
@@ -226,6 +227,7 @@ These values are:
 
 - `app.module` : mandatory name of the project. It's being used as a module name when generating Angular modules, like `$templateCache` or constants modules.
 - `repository` the GIT url of your application, used in the `release` and `prerelease` tasks.
+- `skipAppCacheGeneration` allows to do not generate appcache manifest as it is [not recommended anymore](https://html.spec.whatwg.org/multipage/browsers.html#offline)
 - `partials` is a glob pattern to specify what files should bne considered as Angular `$templateCache` templates. Refer to the [Partials](#partials) section for details.
 - `server` configuration options for the web server like port number, live reload port number, host name etc.
 - `serverDist` configuration options for the web server started from `dist` by using `server:dist` task.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,6 +78,7 @@ gulp.task('dist:serve', ['dist', 'server:dist']);
 // Set the config to use across the gulp build
 gulp.config = {
     repository: 'http://nykredit.github.com/gript.git',
+    skipAppCacheGeneration: true,
     app: {
         module: 'gript'
     },

--- a/package/sample_configs/gulpfile.js
+++ b/package/sample_configs/gulpfile.js
@@ -9,7 +9,8 @@ require('gript')(gulp);
 // Set the config to use across the gulp build
 gulp.config = {
     repository: 'http://git.nykreditnet.net/scm/dist/xpa-no-specified-project.git',
-	app: {
+    skipAppCacheGeneration: true,
+    app: {
         module: 'myApp',
         constantsFile: 'app/constants.json'
     },

--- a/tasks/dist.gulp.js
+++ b/tasks/dist.gulp.js
@@ -38,7 +38,11 @@ module.exports = function (gulp, paths) {
         };
 
     gulp.task('dist', function (callback) {
-        sequence('clean', ['appcache-create', 'appcache-include'], callback);
+        if (gulp.config.skipAppCacheGeneration) {
+            sequence('clean', ['minify'], callback);
+        } else {
+            sequence('clean', ['appcache-create', 'appcache-include'], callback);
+        }
     });
 
     gulp.task('appcache-create', ['minify'], function () {


### PR DESCRIPTION
Appcache manifest generation made optional with new property 'skipAppCacheGeneration' added to gulpfile.config